### PR TITLE
Fix crashes 

### DIFF
--- a/opencv.go
+++ b/opencv.go
@@ -156,8 +156,8 @@ func resize(src *C.IplImage, options Options) (*ProcessResult, error) {
 
 		// Determine proper ROI rectangle placement
 		rect := C.CvRect{}
-		rect.width = C.int(math.Floor(float64(src.width) * ratio))
-		rect.height = C.int(math.Floor(float64(src.height) * ratio))
+		rect.width = C.int(math.Max(math.Floor(float64(src.width) * ratio), 1))
+		rect.height = C.int(math.Max(math.Floor(float64(src.height) * ratio), 1))
 		switch options.Gravity {
 		case CENTER:
 			rect.x = (size.width - rect.width) / 2

--- a/opencv.go
+++ b/opencv.go
@@ -54,7 +54,7 @@ func calcNewSize(options Options) (int, int) {
 	if options.MaxSide > 0 {
 		maxSide := options.MaxSide
 		if width <= maxSide && height <= maxSide {
-			return width, height
+			return max(width, 1), max(height, 1)
 		}
 		var ratio float32
 		if width >= height {
@@ -64,30 +64,37 @@ func calcNewSize(options Options) (int, int) {
 		}
 		width = int(float32(width) * ratio)
 		height = int(float32(height) * ratio)
-		return width, height
+		return max(width, 1), max(height, 1)
 	}
 	if options.MaxHeight > 0 {
 		maxHeight := options.MaxHeight
 		if height <= maxHeight {
-			return width, height
+			return max(width, 1), max(height, 1)
 		}
 		ratio := float32(maxHeight) / float32(height)
 		width = int(float32(width) * ratio)
 		height = int(float32(height) * ratio)
-		return width, height
+		return max(width, 1), max(height, 1)
 	}
 	if options.MaxWidth > 0 {
 		maxWidth := options.MaxWidth
 		if width <= maxWidth {
-			return width, height
+			return max(width, 1), max(height, 1)
 		}
 		ratio := float32(maxWidth) / float32(width)
 		width = int(float32(width) * ratio)
 		height = int(float32(height) * ratio)
-		return width, height
+		return max(width, 1), max(height, 1)
 	}
 
-	return width, height
+	return max(width, 1), max(height, 1)
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func resize(src *C.IplImage, options Options) (*ProcessResult, error) {


### PR DESCRIPTION
```libpng error: PNG input buffer is incomplete
libpng error: PNG input buffer is incomplete
OpenCV Error: Unknown error code -10 (Raw image encoder error: Empty JPEG image (DNL not supported)) in throwOnEror, file /tmp/opencv/opencv-3.2.0/modules/imgcodecs/src/grfmt_base.cpp, line 139
OpenCV Error: Unknown error code -10 (Raw image encoder error: Empty JPEG image (DNL not supported)) in throwOnEror, file /tmp/opencv/opencv-3.2.0/modules/imgcodecs/src/grfmt_base.cpp, line 139
OpenCV Error: Unknown error code -10 (Raw image encoder error: Empty JPEG image (DNL not supported)) in throwOnEror, file /tmp/opencv/opencv-3.2.0/modules/imgcodecs/src/grfmt_base.cpp, line 139
OpenCV Error: Unknown error code -10 (Raw image encoder error: Empty JPEG image (DNL not supported)) in throwOnEror, file /tmp/opencv/opencv-3.2.0/modules/imgcodecs/src/grfmt_base.cpp, line 139
terminate called recursively
terminate called recursively
terminate called after throwing an instance of 'terminate called recursively
cv::Exception'
  what():  /tmp/opencv/opencv-3.2.0/modules/imgcodecs/src/grfmt_base.cpp:139: error: (-10) Raw image encoder error: Empty JPEG image (DNL not supported) in function throwOnEror

SIGABRT: abort
PC=0x7f43227141f7 m=33 sigcode=18446744073709551610
signal arrived during cgo execution

goroutine 10597442 [syscall, locked to thread]:

............................................

Corrupt JPEG data: 13952 extraneous bytes before marker 0xd9
Corrupt JPEG data: premature end of data segment
Corrupt JPEG data: premature end of data segment
Corrupt JPEG data: premature end of data segment
Corrupt JPEG data: premature end of data segment```